### PR TITLE
Allowed workday and pause end times to be empty on workday editing action.

### DIFF
--- a/app/CanInputUserTimeZone.php
+++ b/app/CanInputUserTimeZone.php
@@ -5,7 +5,7 @@ use Carbon\Carbon;
 use Config;
 
 /**
- * This trait is supposed to simplify converting user imput times and date times to the applications timezone.
+ * This trait is supposed to simplify converting user input times and date times to the applications timezone.
  */
 trait CanInputUserTimeZone
 {

--- a/app/Http/Controllers/TrackingController.php
+++ b/app/Http/Controllers/TrackingController.php
@@ -138,13 +138,16 @@ class TrackingController extends Controller
 		$workday = Workday::find($recordId);
 
 		$workday->start = $workday->setTimeFromUserTimeZone($workday->start, $request->get('day_start'));
-		$workday->end = $workday->setTimeFromUserTimeZone($workday->end, $request->get('day_end'));
+		$dayEnd = $request->get('day_end');
+		if (empty($dayEnd) === false) {
+			$workday->end = $workday->setTimeFromUserTimeZone($workday->end, $dayEnd);
+		}
 
 		$workday->save();
 
 		// pauses handling
-		$pauseStarts = $request->get('pause_starts');
-		$pauseEnds = $request->get('pause_ends');
+		$pauseStarts = $request->get('pause_starts', []);
+		$pauseEnds = $request->get('pause_ends', []);
 
 		foreach ($pauseStarts as $id => $pauseStart) {
 			$pauseEnd = $pauseEnds[$id];
@@ -152,7 +155,9 @@ class TrackingController extends Controller
 			$pause = Pause::find($id);
 
 			$pause->start = $pause->setTimeFromUserTimeZone($pause->start, $pauseStart);
-			$pause->end = $pause->setTimeFromUserTimeZone($pause->end, $pauseEnd);
+			if (empty($pauseEnd) === false) {
+				$pause->end = $pause->setTimeFromUserTimeZone($pause->end, $pauseEnd);
+			}
 
 			$pause->save();
 		}


### PR DESCRIPTION
This implements #7.
